### PR TITLE
refactor(changelog-rule): redesign ChangeLogRule API

### DIFF
--- a/liquibase-linter-core/src/main/java/io/github/liquibaselinter/config/RuleConfig.java
+++ b/liquibase-linter-core/src/main/java/io/github/liquibaselinter/config/RuleConfig.java
@@ -11,6 +11,8 @@ import java.util.regex.Pattern;
 @JsonDeserialize(builder = RuleConfig.RuleConfigBuilder.class)
 public final class RuleConfig {
 
+    public static final RuleConfig EMPTY = builder().build();
+
     private static final String DYNAMIC_VALUE = "{{value}}";
 
     private final boolean enabled;

--- a/liquibase-linter-core/src/main/java/io/github/liquibaselinter/rules/AbstractLintRule.java
+++ b/liquibase-linter-core/src/main/java/io/github/liquibaselinter/rules/AbstractLintRule.java
@@ -6,6 +6,7 @@ import io.github.liquibaselinter.rules.checker.PatternChecker;
 import java.util.Arrays;
 import java.util.Optional;
 
+@Deprecated
 public abstract class AbstractLintRule implements LintRule {
     private final String name;
     private final String message;
@@ -22,7 +23,6 @@ public abstract class AbstractLintRule implements LintRule {
         return name;
     }
 
-    @Override
     public void configure(RuleConfig ruleConfig) {
         this.ruleConfig = ruleConfig;
         if (ruleConfig.hasPattern()) {
@@ -64,7 +64,6 @@ public abstract class AbstractLintRule implements LintRule {
         return value != null && value.length() > getConfig().getMaxLength();
     }
 
-    @Override
     public String getMessage() {
         return getMessageTemplate();
     }

--- a/liquibase-linter-core/src/main/java/io/github/liquibaselinter/rules/ChangeLogRule.java
+++ b/liquibase-linter-core/src/main/java/io/github/liquibaselinter/rules/ChangeLogRule.java
@@ -1,11 +1,10 @@
 package io.github.liquibaselinter.rules;
 
+import io.github.liquibaselinter.config.RuleConfig;
 import liquibase.changelog.DatabaseChangeLog;
 
-public interface ChangeLogRule extends LintRule {
-    boolean invalid(DatabaseChangeLog changeLog);
+import java.util.Collection;
 
-    default String getMessage(DatabaseChangeLog changeLog) {
-        return getMessage();
-    }
+public interface ChangeLogRule extends LintRule {
+    Collection<RuleViolation> check(DatabaseChangeLog changeLog, RuleConfig ruleConfig);
 }

--- a/liquibase-linter-core/src/main/java/io/github/liquibaselinter/rules/ChangeRule.java
+++ b/liquibase-linter-core/src/main/java/io/github/liquibaselinter/rules/ChangeRule.java
@@ -1,8 +1,13 @@
 package io.github.liquibaselinter.rules;
 
+import io.github.liquibaselinter.config.RuleConfig;
 import liquibase.change.Change;
 
 public interface ChangeRule extends LintRule {
+
+    void configure(RuleConfig ruleConfig);
+
+    String getMessage();
 
     boolean supports(Change change);
 

--- a/liquibase-linter-core/src/main/java/io/github/liquibaselinter/rules/ChangeSetRule.java
+++ b/liquibase-linter-core/src/main/java/io/github/liquibaselinter/rules/ChangeSetRule.java
@@ -1,9 +1,15 @@
 package io.github.liquibaselinter.rules;
 
+import io.github.liquibaselinter.config.RuleConfig;
 import liquibase.changelog.ChangeSet;
 
 public interface ChangeSetRule extends LintRule {
+
+    String getMessage();
+
     boolean invalid(ChangeSet changeSet);
+
+    void configure(RuleConfig ruleConfig);
 
     default String getMessage(ChangeSet changeSet) {
         return getMessage();

--- a/liquibase-linter-core/src/main/java/io/github/liquibaselinter/rules/LintRule.java
+++ b/liquibase-linter-core/src/main/java/io/github/liquibaselinter/rules/LintRule.java
@@ -1,11 +1,5 @@
 package io.github.liquibaselinter.rules;
 
-import io.github.liquibaselinter.config.RuleConfig;
-
 public interface LintRule {
     String getName();
-
-    void configure(RuleConfig ruleConfig);
-
-    String getMessage();
 }

--- a/liquibase-linter-core/src/main/java/io/github/liquibaselinter/rules/LintRuleChecker.java
+++ b/liquibase-linter-core/src/main/java/io/github/liquibaselinter/rules/LintRuleChecker.java
@@ -1,0 +1,42 @@
+package io.github.liquibaselinter.rules;
+
+import io.github.liquibaselinter.config.RuleConfig;
+import io.github.liquibaselinter.rules.checker.PatternChecker;
+
+import java.util.Optional;
+
+public class LintRuleChecker {
+    private final RuleConfig ruleConfig;
+    private final PatternChecker patternChecker;
+
+    public LintRuleChecker(RuleConfig ruleConfig) {
+        this.ruleConfig = ruleConfig;
+        if (ruleConfig.hasPattern()) {
+            this.patternChecker = new PatternChecker(ruleConfig);
+        } else {
+            this.patternChecker = null;
+        }
+    }
+
+    public boolean checkBlank(String value) {
+        return value != null && !value.isEmpty();
+    }
+
+    public boolean checkNotBlank(String value) {
+        return value == null || value.isEmpty();
+    }
+
+    public boolean checkPattern(String value, Object subject) {
+        return Optional.ofNullable(patternChecker)
+            .map(checker -> checker.check(value, subject))
+            .orElse(false);
+    }
+
+    public boolean checkMandatoryPattern(String value, Object subject) {
+        return checkNotBlank(value) || patternChecker.check(value, subject);
+    }
+
+    public boolean checkMaxLength(String value) {
+        return value != null && value.length() > ruleConfig.getMaxLength();
+    }
+}

--- a/liquibase-linter-core/src/main/java/io/github/liquibaselinter/rules/LintRuleMessageGenerator.java
+++ b/liquibase-linter-core/src/main/java/io/github/liquibaselinter/rules/LintRuleMessageGenerator.java
@@ -1,0 +1,36 @@
+package io.github.liquibaselinter.rules;
+
+import io.github.liquibaselinter.config.RuleConfig;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+public class LintRuleMessageGenerator {
+    private final String defaultMessage;
+    private final RuleConfig ruleConfig;
+
+    public LintRuleMessageGenerator(String defaultMessage, RuleConfig ruleConfig) {
+        this.defaultMessage = defaultMessage;
+        this.ruleConfig = ruleConfig;
+    }
+
+    public String getPatternForMessage(Object subject) {
+        return ruleConfig.hasDynamicPattern()
+            ? ruleConfig.getDynamicPattern(ruleConfig.getDynamicValue(subject)).pattern()
+            : ruleConfig.getPatternString();
+    }
+
+    public String getMessage() {
+        return getMessageTemplate();
+    }
+
+    public String getMessageTemplate() {
+        return Optional.ofNullable(ruleConfig.getErrorMessage()).orElse(defaultMessage);
+    }
+
+    public String formatMessage(Object... stuff) {
+        return String.format(getMessageTemplate(), Arrays.stream(stuff)
+            .map(thing -> Optional.ofNullable(thing).orElse(""))
+            .toArray());
+    }
+}

--- a/liquibase-linter-core/src/main/java/io/github/liquibaselinter/rules/RuleViolation.java
+++ b/liquibase-linter-core/src/main/java/io/github/liquibaselinter/rules/RuleViolation.java
@@ -1,0 +1,22 @@
+package io.github.liquibaselinter.rules;
+
+import java.util.StringJoiner;
+
+public class RuleViolation {
+    private final String message;
+
+    public RuleViolation(String message) {
+        this.message = message;
+    }
+
+    public String message() {
+        return message;
+    }
+
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", RuleViolation.class.getSimpleName() + "[", "]")
+            .add("message='" + message + "'")
+            .toString();
+    }
+}

--- a/liquibase-linter-core/src/test/java/io/github/liquibaselinter/rules/core/ChangeLogFileNameRuleTest.java
+++ b/liquibase-linter-core/src/test/java/io/github/liquibaselinter/rules/core/ChangeLogFileNameRuleTest.java
@@ -1,6 +1,7 @@
 package io.github.liquibaselinter.rules.core;
 
 import io.github.liquibaselinter.config.RuleConfig;
+import io.github.liquibaselinter.rules.RuleViolation;
 import liquibase.changelog.DatabaseChangeLog;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -9,22 +10,28 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class ChangeLogFileNameRuleTest {
 
-    private final ChangeLogFileNameRule changeLogFileNameRule = new ChangeLogFileNameRule();
+    private final ChangeLogFileNameRule rule = new ChangeLogFileNameRule();
 
     @Test
     @DisplayName("ChangeLog filename must follow pattern")
     void changeLogFileNameMustFollowPattern() {
-        changeLogFileNameRule.configure(RuleConfig.builder().withPattern("^[^ ]+$").build());
+        RuleConfig ruleConfig = RuleConfig.builder().withPattern("^[^ ]+$").build();
 
-        assertThat(changeLogFileNameRule.invalid(changeLogWithFilePath("//test/dir/this has spaces.xml"))).isTrue();
-        assertThat(changeLogFileNameRule.invalid(changeLogWithFilePath("//test/dir/this-has-spaces.xml"))).isFalse();
+        assertThat(rule.check(changeLogWithFilePath("//test/dir/this has spaces.xml"), ruleConfig))
+            .extracting(RuleViolation::message)
+            .containsExactly("ChangeLog filename '//test/dir/this has spaces.xml' must follow pattern '^[^ ]+$'");
+
+        assertThat(rule.check(changeLogWithFilePath("//test/dir/this-has-spaces.xml"), ruleConfig)).isEmpty();
     }
 
     @DisplayName("ChangeLog filename rule should support formatted error message with pattern arg")
     @Test
     void changeLogFileNameRuleShouldReturnFormattedErrorMessage() {
-        changeLogFileNameRule.configure(RuleConfig.builder().withPattern("^\\d{8}_[a-z_]+$").withErrorMessage("ChangeLog has a filename '%s' that doesn't match pattern '%s'").build());
-        assertThat(changeLogFileNameRule.getMessage(changeLogWithFilePath("001_create_table_foo"))).isEqualTo("ChangeLog has a filename '001_create_table_foo' that doesn't match pattern '^\\d{8}_[a-z_]+$'");
+        RuleConfig ruleConfig = RuleConfig.builder().withPattern("^\\d{8}_[a-z_]+$").withErrorMessage("ChangeLog has a filename '%s' that doesn't match pattern '%s'").build();
+
+        assertThat(rule.check(changeLogWithFilePath("001_create_table_foo"), ruleConfig))
+            .extracting(RuleViolation::message)
+            .containsExactly("ChangeLog has a filename '001_create_table_foo' that doesn't match pattern '^\\d{8}_[a-z_]+$'");
     }
 
     private DatabaseChangeLog changeLogWithFilePath(String filePath) {

--- a/liquibase-linter-core/src/test/java/io/github/liquibaselinter/rules/core/NoPreconditionsRuleTest.java
+++ b/liquibase-linter-core/src/test/java/io/github/liquibaselinter/rules/core/NoPreconditionsRuleTest.java
@@ -1,6 +1,7 @@
 package io.github.liquibaselinter.rules.core;
 
 import io.github.liquibaselinter.config.RuleConfig;
+import io.github.liquibaselinter.rules.RuleViolation;
 import liquibase.change.core.InsertDataChange;
 import liquibase.changelog.ChangeSet;
 import liquibase.changelog.DatabaseChangeLog;
@@ -40,10 +41,11 @@ class NoPreconditionsRuleTest {
     @DisplayName("Should fail on preconditions in changeLog")
     @Test
     void shouldFailWhenPreconditionsInChangeLog() {
-        rule.configure(RuleConfig.builder().build());
         DatabaseChangeLog changeLog = mock(DatabaseChangeLog.class, RETURNS_DEEP_STUBS);
         when(changeLog.getPreconditions().getNestedPreconditions()).thenReturn(Collections.singletonList(mock(Precondition.class)));
 
-        assertThat(rule.invalid(changeLog)).isTrue();
+        assertThat(rule.check(changeLog, RuleConfig.EMPTY))
+            .extracting(RuleViolation::message)
+            .containsExactly("Preconditions are not allowed in this project");
     }
 }


### PR DESCRIPTION
- `invalid(DatabaseChangeLog)` method returning a boolean is replaced by a `check(DatabaseChangeLog, RuleConfig)` method that returns a collection of detected violations.
- the `configure(RuleConfig)` method has been removed, allowing rules to be stateless.
- the `getMessage()` method has also been removed, and is now an internal implementation detail of rules
- remove dependency to `AbstractLintRule` that is deprecated to avoid inheritance. Instead rules should use composition, and can uses newly introduced `LintRuleChecker` and `LintRuleMessageGenerator` that provides similar features that were provided by `AbstractLintRule`