### PR TITLE
refactor(changeset-rule): redesign ChangeSetRule API

### DIFF
--- a/liquibase-linter-core/src/main/java/io/github/liquibaselinter/RuleRunner.java
+++ b/liquibase-linter-core/src/main/java/io/github/liquibaselinter/RuleRunner.java
@@ -86,13 +86,12 @@ class RuleRunner {
             final List<RuleConfig> configs = config.forRule(ruleName);
             for (RuleConfig ruleConfig : configs) {
                 if (isEnabled(ruleConfig) && ConditionHelper.evaluateCondition(ruleConfig, changeSet)) {
-                    changeSetRule.configure(ruleConfig);
-                    final String message = changeSetRule.getMessage(changeSet);
-
-                    if (changeSetRule.invalid(changeSet)) {
-                        handleViolation(changeLog, changeSet, ruleName, message);
-                    } else {
-                        reportItems.add(ReportItem.passed(changeLog, changeSet, ruleName, message));
+                    Collection<RuleViolation> violations = changeSetRule.check(changeSet, ruleConfig);
+                    for (RuleViolation violation : violations) {
+                        handleViolation(changeLog, changeSet, ruleName, violation.message());
+                    }
+                    if (violations.isEmpty()) {
+                        reportItems.add(ReportItem.passed(changeLog, changeSet, ruleName, ""));
                     }
                 }
             }

--- a/liquibase-linter-core/src/main/java/io/github/liquibaselinter/rules/ChangeSetRule.java
+++ b/liquibase-linter-core/src/main/java/io/github/liquibaselinter/rules/ChangeSetRule.java
@@ -3,15 +3,8 @@ package io.github.liquibaselinter.rules;
 import io.github.liquibaselinter.config.RuleConfig;
 import liquibase.changelog.ChangeSet;
 
+import java.util.Collection;
+
 public interface ChangeSetRule extends LintRule {
-
-    String getMessage();
-
-    boolean invalid(ChangeSet changeSet);
-
-    void configure(RuleConfig ruleConfig);
-
-    default String getMessage(ChangeSet changeSet) {
-        return getMessage();
-    }
+    Collection<RuleViolation> check(ChangeSet changeSet, RuleConfig ruleConfig);
 }

--- a/liquibase-linter-core/src/main/java/io/github/liquibaselinter/rules/core/ChangetSetAuthorRule.java
+++ b/liquibase-linter-core/src/main/java/io/github/liquibaselinter/rules/core/ChangetSetAuthorRule.java
@@ -1,26 +1,37 @@
 package io.github.liquibaselinter.rules.core;
 
 import com.google.auto.service.AutoService;
-import io.github.liquibaselinter.rules.AbstractLintRule;
+import io.github.liquibaselinter.config.RuleConfig;
 import io.github.liquibaselinter.rules.ChangeSetRule;
+import io.github.liquibaselinter.rules.LintRuleChecker;
+import io.github.liquibaselinter.rules.LintRuleMessageGenerator;
+import io.github.liquibaselinter.rules.RuleViolation;
 import liquibase.changelog.ChangeSet;
 
+import java.util.Collection;
+import java.util.Collections;
+
 @AutoService(ChangeSetRule.class)
-public class ChangetSetAuthorRule extends AbstractLintRule implements ChangeSetRule {
+public class ChangetSetAuthorRule implements ChangeSetRule {
     private static final String NAME = "changeset-author";
-    private static final String MESSAGE = "ChangeSet author '%s' does not follow pattern '%s'";
+    private static final String DEFAULT_MESSAGE = "ChangeSet author '%s' does not follow pattern '%s'";
 
-    public ChangetSetAuthorRule() {
-        super(NAME, MESSAGE);
+    @Override
+    public String getName() {
+        return NAME;
     }
 
     @Override
-    public boolean invalid(ChangeSet changeSet) {
-        return checkMandatoryPattern(changeSet.getAuthor(), changeSet);
+    public Collection<RuleViolation> check(ChangeSet changeSet, RuleConfig ruleConfig) {
+        LintRuleChecker ruleChecker = new LintRuleChecker(ruleConfig);
+        if (ruleChecker.checkMandatoryPattern(changeSet.getAuthor(), changeSet)) {
+            return Collections.singleton(new RuleViolation(getMessage(changeSet, ruleConfig)));
+        }
+        return Collections.emptyList();
     }
 
-    @Override
-    public String getMessage(ChangeSet changeSet) {
-        return formatMessage(changeSet.getAuthor(), ruleConfig.getPatternString());
+    private String getMessage(ChangeSet changeSet, RuleConfig ruleConfig) {
+        LintRuleMessageGenerator messageGenerator = new LintRuleMessageGenerator(DEFAULT_MESSAGE, ruleConfig);
+        return messageGenerator.formatMessage(changeSet.getAuthor(), ruleConfig.getPatternString());
     }
 }

--- a/liquibase-linter-core/src/main/java/io/github/liquibaselinter/rules/core/ChangetSetIdRule.java
+++ b/liquibase-linter-core/src/main/java/io/github/liquibaselinter/rules/core/ChangetSetIdRule.java
@@ -1,26 +1,36 @@
 package io.github.liquibaselinter.rules.core;
 
 import com.google.auto.service.AutoService;
-import io.github.liquibaselinter.rules.AbstractLintRule;
+import io.github.liquibaselinter.config.RuleConfig;
 import io.github.liquibaselinter.rules.ChangeSetRule;
+import io.github.liquibaselinter.rules.LintRuleChecker;
+import io.github.liquibaselinter.rules.LintRuleMessageGenerator;
+import io.github.liquibaselinter.rules.RuleViolation;
 import liquibase.changelog.ChangeSet;
 
+import java.util.Collection;
+import java.util.Collections;
+
 @AutoService(ChangeSetRule.class)
-public class ChangetSetIdRule extends AbstractLintRule implements ChangeSetRule {
+public class ChangetSetIdRule implements ChangeSetRule {
     private static final String NAME = "changeset-id";
-    private static final String MESSAGE = "ChangeSet id '%s' does not follow pattern '%s'";
+    private static final String DEFAULT_MESSAGE = "ChangeSet id '%s' does not follow pattern '%s'";
 
-    public ChangetSetIdRule() {
-        super(NAME, MESSAGE);
+    @Override
+    public String getName() {
+        return NAME;
     }
 
     @Override
-    public boolean invalid(ChangeSet changeSet) {
-        return checkMandatoryPattern(changeSet.getId(), changeSet);
+    public Collection<RuleViolation> check(ChangeSet changeSet, RuleConfig ruleConfig) {
+        LintRuleChecker ruleChecker = new LintRuleChecker(ruleConfig);
+        if (ruleChecker.checkMandatoryPattern(changeSet.getId(), changeSet)) {
+            return Collections.singleton(new RuleViolation(getMessage(changeSet, ruleConfig)));
+        }
+        return Collections.emptyList();
     }
 
-    @Override
-    public String getMessage(ChangeSet changeSet) {
-        return formatMessage(changeSet.getId(), ruleConfig.getPatternString());
+    private String getMessage(ChangeSet changeSet, RuleConfig ruleConfig) {
+        return new LintRuleMessageGenerator(DEFAULT_MESSAGE, ruleConfig).formatMessage(changeSet.getId(), ruleConfig.getPatternString());
     }
 }

--- a/liquibase-linter-core/src/main/java/io/github/liquibaselinter/rules/core/HasCommentRule.java
+++ b/liquibase-linter-core/src/main/java/io/github/liquibaselinter/rules/core/HasCommentRule.java
@@ -1,30 +1,46 @@
 package io.github.liquibaselinter.rules.core;
 
 import com.google.auto.service.AutoService;
-import io.github.liquibaselinter.rules.AbstractLintRule;
+import io.github.liquibaselinter.config.RuleConfig;
 import io.github.liquibaselinter.rules.ChangeSetRule;
+import io.github.liquibaselinter.rules.LintRuleChecker;
+import io.github.liquibaselinter.rules.LintRuleMessageGenerator;
+import io.github.liquibaselinter.rules.RuleViolation;
 import liquibase.change.core.TagDatabaseChange;
 import liquibase.changelog.ChangeSet;
 
-@AutoService({ChangeSetRule.class})
-public class HasCommentRule extends AbstractLintRule implements ChangeSetRule {
-    private static final String NAME = "has-comment";
-    private static final String MESSAGE = "Change set must have a comment";
+import java.util.Collection;
+import java.util.Collections;
 
-    public HasCommentRule() {
-        super(NAME, MESSAGE);
+@AutoService({ChangeSetRule.class})
+public class HasCommentRule implements ChangeSetRule {
+    private static final String NAME = "has-comment";
+    private static final String DEFAULT_MESSAGE = "Change set must have a comment";
+
+    @Override
+    public String getName() {
+        return NAME;
     }
 
     @Override
-    public boolean invalid(ChangeSet changeSet) {
+    public Collection<RuleViolation> check(ChangeSet changeSet, RuleConfig ruleConfig) {
         if (changeSet.getChanges().stream().anyMatch(TagDatabaseChange.class::isInstance)) {
             /*
             https://github.com/whiteclarkegroup/liquibase-linter/issues/90
             tagDatabase changes cannot have any siblings in a changeSet - not even comments
             so we have to make an exception here
              */
-            return false;
+            return Collections.emptyList();
         }
-        return checkNotBlank(changeSet.getComments());
+
+        LintRuleChecker ruleChecker = new LintRuleChecker(ruleConfig);
+        if (ruleChecker.checkNotBlank(changeSet.getComments())) {
+            return Collections.singleton(new RuleViolation(getMessage(ruleConfig)));
+        }
+        return Collections.emptyList();
+    }
+
+    private String getMessage(RuleConfig ruleConfig) {
+        return new LintRuleMessageGenerator(DEFAULT_MESSAGE, ruleConfig).getMessage();
     }
 }

--- a/liquibase-linter-core/src/main/java/io/github/liquibaselinter/rules/core/HasContextRule.java
+++ b/liquibase-linter-core/src/main/java/io/github/liquibaselinter/rules/core/HasContextRule.java
@@ -1,21 +1,34 @@
 package io.github.liquibaselinter.rules.core;
 
 import com.google.auto.service.AutoService;
-import io.github.liquibaselinter.rules.AbstractLintRule;
+import io.github.liquibaselinter.config.RuleConfig;
 import io.github.liquibaselinter.rules.ChangeSetRule;
+import io.github.liquibaselinter.rules.LintRuleMessageGenerator;
+import io.github.liquibaselinter.rules.RuleViolation;
 import liquibase.changelog.ChangeSet;
 
-@AutoService({ChangeSetRule.class})
-public class HasContextRule extends AbstractLintRule implements ChangeSetRule {
-    private static final String NAME = "has-context";
-    private static final String MESSAGE = "Should have at least one context on the change set";
+import java.util.Collection;
+import java.util.Collections;
 
-    public HasContextRule() {
-        super(NAME, MESSAGE);
+@AutoService({ChangeSetRule.class})
+public class HasContextRule implements ChangeSetRule {
+    private static final String NAME = "has-context";
+    private static final String DEFAULT_MESSAGE = "Should have at least one context on the change set";
+
+    @Override
+    public String getName() {
+        return NAME;
     }
 
     @Override
-    public boolean invalid(ChangeSet changeSet) {
-        return changeSet.getContexts().isEmpty();
+    public Collection<RuleViolation> check(ChangeSet changeSet, RuleConfig ruleConfig) {
+        if (changeSet.getContexts().isEmpty()) {
+            return Collections.singleton(new RuleViolation(getMessage(ruleConfig)));
+        }
+        return Collections.emptyList();
+    }
+
+    private String getMessage(RuleConfig ruleConfig) {
+        return new LintRuleMessageGenerator(DEFAULT_MESSAGE, ruleConfig).getMessage();
     }
 }

--- a/liquibase-linter-core/src/main/java/io/github/liquibaselinter/rules/core/IsolateDDLChangesRule.java
+++ b/liquibase-linter-core/src/main/java/io/github/liquibaselinter/rules/core/IsolateDDLChangesRule.java
@@ -1,22 +1,35 @@
 package io.github.liquibaselinter.rules.core;
 
 import com.google.auto.service.AutoService;
-import io.github.liquibaselinter.rules.AbstractLintRule;
+import io.github.liquibaselinter.config.RuleConfig;
 import io.github.liquibaselinter.rules.ChangeSetRule;
 import io.github.liquibaselinter.rules.Changes;
+import io.github.liquibaselinter.rules.LintRuleMessageGenerator;
+import io.github.liquibaselinter.rules.RuleViolation;
 import liquibase.changelog.ChangeSet;
 
-@AutoService({ChangeSetRule.class})
-public class IsolateDDLChangesRule extends AbstractLintRule implements ChangeSetRule {
-    private static final String NAME = "isolate-ddl-changes";
-    private static final String MESSAGE = "Should only have a single ddl change per change set";
+import java.util.Collection;
+import java.util.Collections;
 
-    public IsolateDDLChangesRule() {
-        super(NAME, MESSAGE);
+@AutoService({ChangeSetRule.class})
+public class IsolateDDLChangesRule implements ChangeSetRule {
+    private static final String NAME = "isolate-ddl-changes";
+    private static final String DEFAULT_MESSAGE = "Should only have a single ddl change per change set";
+
+    @Override
+    public String getName() {
+        return NAME;
     }
 
     @Override
-    public boolean invalid(ChangeSet changeSet) {
-        return changeSet.getChanges().stream().filter(Changes::isDDL).count() > 1;
+    public Collection<RuleViolation> check(ChangeSet changeSet, RuleConfig ruleConfig) {
+        if (changeSet.getChanges().stream().filter(Changes::isDDL).count() > 1) {
+            return Collections.singleton(new RuleViolation(getMessage(ruleConfig)));
+        }
+        return Collections.emptyList();
+    }
+
+    private String getMessage(RuleConfig ruleConfig) {
+        return new LintRuleMessageGenerator(DEFAULT_MESSAGE, ruleConfig).getMessage();
     }
 }

--- a/liquibase-linter-core/src/main/java/io/github/liquibaselinter/rules/core/SeparateDDLChangesRule.java
+++ b/liquibase-linter-core/src/main/java/io/github/liquibaselinter/rules/core/SeparateDDLChangesRule.java
@@ -1,45 +1,61 @@
 package io.github.liquibaselinter.rules.core;
 
 import com.google.auto.service.AutoService;
-import io.github.liquibaselinter.rules.AbstractLintRule;
+import io.github.liquibaselinter.config.RuleConfig;
 import io.github.liquibaselinter.rules.ChangeSetRule;
 import io.github.liquibaselinter.rules.Changes;
+import io.github.liquibaselinter.rules.LintRuleMessageGenerator;
+import io.github.liquibaselinter.rules.RuleViolation;
 import liquibase.ContextExpression;
 import liquibase.change.Change;
 import liquibase.changelog.ChangeSet;
 
 import java.util.Collection;
+import java.util.Collections;
 
 @AutoService({ChangeSetRule.class})
-public class SeparateDDLChangesRule extends AbstractLintRule implements ChangeSetRule {
+public class SeparateDDLChangesRule implements ChangeSetRule {
     private static final String NAME = "separate-ddl-context";
-    private static final String MESSAGE = "Should have a ddl changes under ddl contexts";
+    private static final String DEFAULT_MESSAGE = "Should have a ddl changes under ddl contexts";
 
-    public SeparateDDLChangesRule() {
-        super(NAME, MESSAGE);
+    @Override
+    public String getName() {
+        return NAME;
     }
 
     @Override
-    public boolean invalid(ChangeSet changeSet) {
+    public Collection<RuleViolation> check(ChangeSet changeSet, RuleConfig ruleConfig) {
+        if (isInvalid(changeSet, ruleConfig)) {
+            return Collections.singleton(new RuleViolation(getMessage(ruleConfig)));
+        }
+        return Collections.emptyList();
+    }
+
+    public boolean isInvalid(ChangeSet changeSet, RuleConfig ruleConfig) {
         ContextExpression contextExpression = changeSet.getContexts();
-        if (contextExpression != null && !contextExpression.getContexts().isEmpty()) {
-            Collection<String> contexts = contextExpression.getContexts();
-            for (Change change : changeSet.getChanges()) {
-                if (Changes.isDDL(change)) {
-                    for (String context : contexts) {
-                        if (!getConfig().getPattern().map(pattern -> pattern.matcher(context).matches()).orElse(true)) {
-                            return true;
-                        }
+        if (contextExpression == null || contextExpression.getContexts().isEmpty()) {
+            return false;
+        }
+        Collection<String> contexts = contextExpression.getContexts();
+        for (Change change : changeSet.getChanges()) {
+            if (Changes.isDDL(change)) {
+                for (String context : contexts) {
+                    if (!ruleConfig.getPattern().map(pattern -> pattern.matcher(context).matches()).orElse(true)) {
+                        return true;
                     }
-                } else if (Changes.isDML(change)) {
-                    for (String context : contexts) {
-                        if (getConfig().getPattern().map(pattern -> pattern.matcher(context).matches()).orElse(false)) {
-                            return true;
-                        }
+                }
+            } else if (Changes.isDML(change)) {
+                for (String context : contexts) {
+                    if (ruleConfig.getPattern().map(pattern -> pattern.matcher(context).matches()).orElse(false)) {
+                        return true;
                     }
                 }
             }
         }
         return false;
+    }
+
+    private String getMessage(RuleConfig ruleConfig) {
+        return new LintRuleMessageGenerator(DEFAULT_MESSAGE, ruleConfig).getMessage();
     }
 }

--- a/liquibase-linter-core/src/test/java/io/github/liquibaselinter/rules/core/ChangetSetAuthorRuleTest.java
+++ b/liquibase-linter-core/src/test/java/io/github/liquibaselinter/rules/core/ChangetSetAuthorRuleTest.java
@@ -3,6 +3,7 @@ package io.github.liquibaselinter.rules.core;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.github.liquibaselinter.config.RuleConfig;
+import io.github.liquibaselinter.rules.RuleViolation;
 import liquibase.changelog.ChangeSet;
 import liquibase.changelog.DatabaseChangeLog;
 import org.junit.jupiter.api.DisplayName;
@@ -20,20 +21,23 @@ class ChangetSetAuthorRuleTest {
     @Test
     @DisplayName("ChangeSet author must follow pattern")
     void changeSetAuthorMustFollowPattern() {
-        rule.configure(RuleConfig.builder().withPattern("^John$").build());
+        RuleConfig ruleConfig = RuleConfig.builder().withPattern("^John$").build();
 
-        assertThat(rule.invalid(changeSetWithAuthor("Jane"))).isTrue();
-        assertThat(rule.getMessage(changeSetWithAuthor("Jane"))).isEqualTo("ChangeSet author 'Jane' does not follow pattern '^John$'");
+        assertThat(rule.check(changeSetWithAuthor("Jane"), ruleConfig))
+            .extracting(RuleViolation::message)
+            .containsExactly("ChangeSet author 'Jane' does not follow pattern '^John$'");
 
-        assertThat(rule.invalid(changeSetWithAuthor("John"))).isFalse();
+        assertThat(rule.check(changeSetWithAuthor("John"), ruleConfig)).isEmpty();
     }
 
     @DisplayName("Should support formatted error message with pattern arg")
     @Test
     void changeSetAuthorRuleShouldReturnFormattedErrorMessage() {
-        rule.configure(RuleConfig.builder().withPattern("^John$").withErrorMessage("The author '%s' must follow pattern '%s'").build());
+        RuleConfig ruleConfig = RuleConfig.builder().withPattern("^John$").withErrorMessage("The author '%s' must follow pattern '%s'").build();
 
-        assertThat(rule.getMessage(changeSetWithAuthor("Jane"))).isEqualTo("The author 'Jane' must follow pattern '^John$'");
+        assertThat(rule.check(changeSetWithAuthor("Jane"), ruleConfig))
+            .extracting(RuleViolation::message)
+            .containsExactly("The author 'Jane' must follow pattern '^John$'");
     }
 
     private ChangeSet changeSetWithAuthor(String author) {

--- a/liquibase-linter-core/src/test/java/io/github/liquibaselinter/rules/core/HasCommentRuleTest.java
+++ b/liquibase-linter-core/src/test/java/io/github/liquibaselinter/rules/core/HasCommentRuleTest.java
@@ -1,5 +1,7 @@
 package io.github.liquibaselinter.rules.core;
 
+import io.github.liquibaselinter.config.RuleConfig;
+import io.github.liquibaselinter.rules.RuleViolation;
 import liquibase.change.core.TagDatabaseChange;
 import liquibase.changelog.ChangeSet;
 import org.junit.jupiter.api.DisplayName;
@@ -20,7 +22,7 @@ class HasCommentRuleTest {
         ChangeSet changeSet = mock(ChangeSet.class, RETURNS_DEEP_STUBS);
         when(changeSet.getComments()).thenReturn("Some comment");
 
-        assertThat(rule.invalid(changeSet)).isFalse();
+        assertThat(rule.check(changeSet, RuleConfig.EMPTY)).isEmpty();
     }
 
     @DisplayName("Should pass when changeSet contains only a tagDatabase change")
@@ -30,7 +32,7 @@ class HasCommentRuleTest {
         when(changeSet.getComments()).thenReturn(null);
         when(changeSet.getChanges()).thenReturn(Collections.singletonList(mock(TagDatabaseChange.class)));
 
-        assertThat(rule.invalid(changeSet)).isFalse();
+        assertThat(rule.check(changeSet, RuleConfig.EMPTY)).isEmpty();
     }
 
     @DisplayName("Should fail when a comment has not been provided on the changeSet")
@@ -39,7 +41,9 @@ class HasCommentRuleTest {
         ChangeSet changeSet = mock(ChangeSet.class, RETURNS_DEEP_STUBS);
         when(changeSet.getComments()).thenReturn(null);
 
-        assertThat(rule.invalid(changeSet)).isTrue();
+        assertThat(rule.check(changeSet, RuleConfig.EMPTY))
+            .extracting(RuleViolation::message)
+            .containsExactly("Change set must have a comment");
     }
 
     @DisplayName("Should fail when a comment is blank on the changeSet")
@@ -48,7 +52,9 @@ class HasCommentRuleTest {
         ChangeSet changeSet = mock(ChangeSet.class, RETURNS_DEEP_STUBS);
         when(changeSet.getComments()).thenReturn("");
 
-        assertThat(rule.invalid(changeSet)).isTrue();
+        assertThat(rule.check(changeSet, RuleConfig.EMPTY))
+            .extracting(RuleViolation::message)
+            .containsExactly("Change set must have a comment");
     }
 
 }

--- a/liquibase-linter-core/src/test/java/io/github/liquibaselinter/rules/core/HasContextRuleTest.java
+++ b/liquibase-linter-core/src/test/java/io/github/liquibaselinter/rules/core/HasContextRuleTest.java
@@ -1,5 +1,7 @@
 package io.github.liquibaselinter.rules.core;
 
+import io.github.liquibaselinter.config.RuleConfig;
+import io.github.liquibaselinter.rules.RuleViolation;
 import liquibase.changelog.ChangeSet;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -17,7 +19,7 @@ class HasContextRuleTest {
         ChangeSet changeSet = mock(ChangeSet.class, RETURNS_DEEP_STUBS);
         when(changeSet.getContexts().isEmpty()).thenReturn(false);
 
-        assertThat(rule.invalid(changeSet)).isFalse();
+        assertThat(rule.check(changeSet, RuleConfig.EMPTY)).isEmpty();
     }
 
     @DisplayName("Should fail when a context has not been provided on the changeSet")
@@ -26,6 +28,8 @@ class HasContextRuleTest {
         ChangeSet changeSet = mock(ChangeSet.class, RETURNS_DEEP_STUBS);
         when(changeSet.getContexts().isEmpty()).thenReturn(true);
 
-        assertThat(rule.invalid(changeSet)).isTrue();
+        assertThat(rule.check(changeSet, RuleConfig.EMPTY))
+            .extracting(RuleViolation::message)
+            .containsExactly("Should have at least one context on the change set");
     }
 }

--- a/liquibase-linter-core/src/test/java/io/github/liquibaselinter/rules/core/IllegalChangeTypesRuleTest.java
+++ b/liquibase-linter-core/src/test/java/io/github/liquibaselinter/rules/core/IllegalChangeTypesRuleTest.java
@@ -19,7 +19,7 @@ class IllegalChangeTypesRuleTest {
     @DisplayName("Null Illegal change type should be valid")
     @Test
     void nullIllegalChangeTypeShouldBeValid() {
-        rule.configure(RuleConfig.builder().build());
+        rule.configure(RuleConfig.EMPTY);
 
         assertThat(rule.invalid(new LoadDataChange())).isFalse();
     }

--- a/liquibase-linter-core/src/test/java/io/github/liquibaselinter/rules/core/IndexTablespaceRuleTest.java
+++ b/liquibase-linter-core/src/test/java/io/github/liquibaselinter/rules/core/IndexTablespaceRuleTest.java
@@ -19,7 +19,7 @@ class IndexTablespaceRuleTest {
     @Test
     @DisplayName("Tablespace should not be empty")
     void indexTablespaceShouldNotBeEmpty() {
-        rule.configure(RuleConfig.builder().build());
+        rule.configure(RuleConfig.EMPTY);
 
         assertThat(rule.invalid(createIndexWithTablespace(null))).isTrue();
         assertThat(rule.getMessage(createIndexWithTablespace(null))).isEqualTo("Tablespace '' of index 'idx_foo' is empty or does not follow pattern ''");

--- a/liquibase-linter-core/src/test/java/io/github/liquibaselinter/rules/core/IsolateDDLChangesRuleTest.java
+++ b/liquibase-linter-core/src/test/java/io/github/liquibaselinter/rules/core/IsolateDDLChangesRuleTest.java
@@ -1,6 +1,8 @@
 package io.github.liquibaselinter.rules.core;
 
+import io.github.liquibaselinter.config.RuleConfig;
 import io.github.liquibaselinter.resolvers.ChangeSetParameterResolver;
+import io.github.liquibaselinter.rules.RuleViolation;
 import liquibase.change.core.AddColumnChange;
 import liquibase.change.core.CreateTableChange;
 import liquibase.changelog.ChangeSet;
@@ -21,13 +23,15 @@ class IsolateDDLChangesRuleTest {
         changeSet.addChange(new CreateTableChange());
         changeSet.addChange(new AddColumnChange());
 
-        assertThat(rule.invalid(changeSet)).isTrue();
+        assertThat(rule.check(changeSet, RuleConfig.EMPTY))
+            .extracting(RuleViolation::message)
+            .containsExactly("Should only have a single ddl change per change set");
     }
 
     @DisplayName("Should allow one ddl change type in a change set")
     @Test
     void shouldAllowOneDDL(ChangeSet changeSet) {
-        assertThat(rule.invalid(changeSet)).isFalse();
+        assertThat(rule.check(changeSet, RuleConfig.EMPTY)).isEmpty();
     }
 
 }

--- a/liquibase-linter-core/src/test/java/io/github/liquibaselinter/rules/core/ModifyDataEnforceWhereTest.java
+++ b/liquibase-linter-core/src/test/java/io/github/liquibaselinter/rules/core/ModifyDataEnforceWhereTest.java
@@ -47,7 +47,7 @@ class ModifyDataEnforceWhereTest {
     @DisplayName("Modify data change should support formatter error messages")
     @Test
     void foreignKeyNameRuleShouldReturnFormattedErrorMessage(ChangeSet changeSet) {
-        rule.configure(RuleConfig.builder().build());
+        rule.configure(RuleConfig.EMPTY);
         assertThat(rule.getMessage(getUpdateDataChange(changeSet, null))).isEqualTo("Modify data on table 'REQUIRES_WHERE' must have a where condition");
         assertThat(rule.getMessage(getDeleteDataChange(changeSet, null))).isEqualTo("Modify data on table 'REQUIRES_WHERE' must have a where condition");
     }

--- a/liquibase-linter-core/src/test/java/io/github/liquibaselinter/rules/core/NoPreconditionsRuleTest.java
+++ b/liquibase-linter-core/src/test/java/io/github/liquibaselinter/rules/core/NoPreconditionsRuleTest.java
@@ -21,21 +21,21 @@ class NoPreconditionsRuleTest {
     @DisplayName("Should pass if no preconditions")
     @Test
     void shouldPassIfNoPreconditions() {
-        rule.configure(RuleConfig.builder().build());
         ChangeSet changeSet = new ChangeSet(mock(DatabaseChangeLog.class));
         changeSet.addChange(new InsertDataChange());
 
-        assertThat(rule.invalid(changeSet)).isFalse();
+        assertThat(rule.check(changeSet, RuleConfig.EMPTY)).isEmpty();
     }
 
     @DisplayName("Should fail on preconditions in changeSet")
     @Test
     void shouldFailWhenPreconditionsInChangeSet() {
-        rule.configure(RuleConfig.builder().build());
         ChangeSet changeSet = mock(ChangeSet.class, RETURNS_DEEP_STUBS);
         when(changeSet.getPreconditions().getNestedPreconditions()).thenReturn(Collections.singletonList(mock(Precondition.class)));
 
-        assertThat(rule.invalid(changeSet)).isTrue();
+        assertThat(rule.check(changeSet, RuleConfig.EMPTY))
+            .extracting(RuleViolation::message)
+            .containsExactly("Preconditions are not allowed in this project");
     }
 
     @DisplayName("Should fail on preconditions in changeLog")

--- a/liquibase-linter-core/src/test/java/io/github/liquibaselinter/rules/core/UniqueConstraintTablespaceRuleTest.java
+++ b/liquibase-linter-core/src/test/java/io/github/liquibaselinter/rules/core/UniqueConstraintTablespaceRuleTest.java
@@ -19,7 +19,7 @@ class UniqueConstraintTablespaceRuleTest {
     @Test
     @DisplayName("Tablespace should not be empty")
     void indexTablespaceShouldNotBeEmpty() {
-        rule.configure(RuleConfig.builder().build());
+        rule.configure(RuleConfig.EMPTY);
 
         assertThat(rule.invalid(createUniqueConstraintWithTablespace(null))).isTrue();
         assertThat(rule.getMessage(createUniqueConstraintWithTablespace(null))).isEqualTo("Tablespace '' of unique constraint 'uniq_constraint_foo' is empty or does not follow pattern ''");


### PR DESCRIPTION
- `invalid(DatabaseChangeLog)` method returning a boolean is replaced by a `check(ChangeSet, RuleConfig)` method that returns a collection of detected violations.
- the `configure(RuleConfig)` method has been removed, allowing rules to be stateless.
- the `getMessage()` method has also been removed, and is now an internal implementation detail of rules
- remove dependency to `AbstractLintRule` that is deprecated to avoid inheritance. Instead rules should use composition, and can uses newly introduced `LintRuleChecker` and `LintRuleMessageGenerator` that provides similar features that were provided by `AbstractLintRule`