### PR TITLE
feat: list error messages on linting failure

### DIFF
--- a/liquibase-linter-core/src/main/java/io/github/liquibaselinter/ChangeLogLinter.java
+++ b/liquibase-linter-core/src/main/java/io/github/liquibaselinter/ChangeLogLinter.java
@@ -11,6 +11,7 @@ import io.github.liquibaselinter.config.RuleConfig;
 import io.github.liquibaselinter.report.ReportItem;
 import java.io.IOException;
 import java.util.*;
+import java.util.stream.Collectors;
 import liquibase.ContextExpression;
 import liquibase.Scope;
 import liquibase.change.Change;
@@ -154,14 +155,18 @@ public class ChangeLogLinter {
                     reporter.processReport(ruleRunner.buildReport());
                 }
             });
-        final long errorCount = ruleRunner
+        final List<ReportItem> errors = ruleRunner
             .buildReport()
             .getItems()
             .stream()
             .filter(item -> item.getType() == ReportItem.ReportItemType.ERROR)
-            .count();
+            .collect(Collectors.toList());
+        final long errorCount = errors.size();
         if (errorCount > 0) {
-            throw new ChangeLogLintingException(String.format("Linting failed with %d errors", errorCount));
+            final String errorList = errors.stream().map(ReportItem::getMessage).collect(joining("\n - ", "\n - ", ""));
+            throw new ChangeLogLintingException(
+                String.format("Linting failed with %d errors: %s", errorCount, errorList)
+            );
         }
     }
 }

--- a/liquibase-linter-core/src/test/java/io/github/liquibaselinter/integration/AggregateErrorsIntegrationTest.java
+++ b/liquibase-linter-core/src/test/java/io/github/liquibaselinter/integration/AggregateErrorsIntegrationTest.java
@@ -8,7 +8,7 @@ class AggregateErrorsIntegrationTest extends LinterIntegrationTest {
             "Should aggregate errors",
             "aggregate-errors/aggregate-errors.xml",
             "aggregate-errors/aggregate-errors.json",
-            "Linting failed with 3 errors"
+            "Linting failed with 3 errors: \n - Change set must have a comment\n - Should have at least one context on the change set\n - Preconditions are not allowed in this project"
         );
     }
 }


### PR DESCRIPTION
Add more details error messages on linting failure as for instance:
```
ERROR: Exception Primary Reason:  Linting failed with 3 errors: 
 - Change set must have a comment
 - Should have at least one context on the change set
 - Preconditions are not allowed in this project
```