### PR TITLE
feat(maven-plugin): support loading changelogs with a file reference using 'classpath:' prefix

### DIFF
--- a/liquibase-linter-maven-plugin/src/main/java/io/github/liquibaselinter/mavenplugin/LintMojo.java
+++ b/liquibase-linter-maven-plugin/src/main/java/io/github/liquibaselinter/mavenplugin/LintMojo.java
@@ -24,7 +24,7 @@ import liquibase.changelog.DatabaseChangeLog;
 import liquibase.database.DatabaseConnection;
 import liquibase.database.OfflineConnection;
 import liquibase.exception.LiquibaseException;
-import liquibase.resource.ClassLoaderResourceAccessor;
+import liquibase.integration.spring.SpringResourceAccessor;
 import liquibase.resource.CompositeResourceAccessor;
 import liquibase.resource.DirectoryResourceAccessor;
 import liquibase.resource.ResourceAccessor;
@@ -36,6 +36,7 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProject;
+import org.springframework.core.io.DefaultResourceLoader;
 
 @Mojo(
     name = "lint",
@@ -108,12 +109,12 @@ public class LintMojo extends AbstractMojo {
 
     private ResourceAccessor buildResourceAccessor() throws MojoExecutionException {
         try (
+            SpringResourceAccessor springResourceAccessor = new SpringResourceAccessor(
+                new DefaultResourceLoader(classLoaderIncludingProjectClasspath())
+            );
             ResourceAccessor baseDirResourceAccessor = new DirectoryResourceAccessor(mavenProject.getBasedir());
-            ResourceAccessor projectClasspathResourceAccessor = new ClassLoaderResourceAccessor(
-                classLoaderIncludingProjectClasspath()
-            )
         ) {
-            return new CompositeResourceAccessor(baseDirResourceAccessor, projectClasspathResourceAccessor);
+            return new CompositeResourceAccessor(springResourceAccessor, baseDirResourceAccessor);
         } catch (Exception exception) {
             throw new MojoExecutionException(exception);
         }

--- a/liquibase-linter-maven-plugin/src/test/java/io/github/liquibaselinter/mavenplugin/LintMojoIT.java
+++ b/liquibase-linter-maven-plugin/src/test/java/io/github/liquibaselinter/mavenplugin/LintMojoIT.java
@@ -37,7 +37,7 @@ class LintMojoIT {
     @MavenTest
     @MavenGoal("test")
     void detect_and_parse_all_changelogs(MavenExecutionResult result) {
-        assertThatLintIssueIsDetectedAndReported(result, "config/liquibase/changelog/001_create_table_example.xml");
+        assertThatLintIssueIsDetectedAndReported(result, "config/liquibase/changelog/002_create_index_example.xml");
     }
 
     private static void assertThatLintIssueIsDetectedAndReported(MavenExecutionResult result, String faultyChangelog) {

--- a/liquibase-linter-maven-plugin/src/test/resources-its/io/github/liquibaselinter/mavenplugin/LintMojoIT/detect_and_parse_all_changelogs/pom.xml
+++ b/liquibase-linter-maven-plugin/src/test/resources-its/io/github/liquibaselinter/mavenplugin/LintMojoIT/detect_and_parse_all_changelogs/pom.xml
@@ -10,6 +10,14 @@
   <artifactId>liquibase-linter-maven-plugin-test</artifactId>
   <version>0.0.1-SNAPSHOT</version>
 
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.batch</groupId>
+      <artifactId>spring-batch-core</artifactId>
+      <version>5.2.1</version>
+    </dependency>
+  </dependencies>
+
   <build>
     <plugins>
       <plugin>

--- a/liquibase-linter-maven-plugin/src/test/resources-its/io/github/liquibaselinter/mavenplugin/LintMojoIT/detect_and_parse_all_changelogs/src/main/resources/config/liquibase/changelog/001_create_table_example.xml
+++ b/liquibase-linter-maven-plugin/src/test/resources-its/io/github/liquibaselinter/mavenplugin/LintMojoIT/detect_and_parse_all_changelogs/src/main/resources/config/liquibase/changelog/001_create_table_example.xml
@@ -12,12 +12,4 @@
       <column name="THIRD" type="NUMBER" />
     </createTable>
   </changeSet>
-
-  <changeSet author="example" id="2">
-    <createIndex catalogName="EXAMPLE" indexName="EXAMPLE_INDEX" tableName="EXAMPLE_TABLE" unique="true">
-      <column name="FIRST" />
-      <column name="SECOND" />
-      <column name="THIRD" />
-    </createIndex>
-  </changeSet>
 </databaseChangeLog>

--- a/liquibase-linter-maven-plugin/src/test/resources-its/io/github/liquibaselinter/mavenplugin/LintMojoIT/detect_and_parse_all_changelogs/src/main/resources/config/liquibase/changelog/002_create_index_example.xml
+++ b/liquibase-linter-maven-plugin/src/test/resources-its/io/github/liquibaselinter/mavenplugin/LintMojoIT/detect_and_parse_all_changelogs/src/main/resources/config/liquibase/changelog/002_create_index_example.xml
@@ -3,6 +3,11 @@
   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
 >
-  <include file="config/liquibase/changelog/001_create_table_example.xml" relativeToChangelogFile="false" />
-  <include file="classpath:config/liquibase/changelog/002_create_index_example.xml" />
+  <changeSet author="example" id="2">
+    <createIndex catalogName="EXAMPLE" indexName="EXAMPLE_INDEX" tableName="EXAMPLE_TABLE" unique="true">
+      <column name="FIRST" />
+      <column name="SECOND" />
+      <column name="THIRD" />
+    </createIndex>
+  </changeSet>
 </databaseChangeLog>

--- a/liquibase-linter-maven-plugin/src/test/resources-its/io/github/liquibaselinter/mavenplugin/LintMojoIT/detect_and_parse_all_changelogs/src/main/resources/config/liquibase/changelog/003_create_spring_batch_schema.xml
+++ b/liquibase-linter-maven-plugin/src/test/resources-its/io/github/liquibaselinter/mavenplugin/LintMojoIT/detect_and_parse_all_changelogs/src/main/resources/config/liquibase/changelog/003_create_spring_batch_schema.xml
@@ -1,0 +1,13 @@
+<databaseChangeLog
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+>
+  <changeSet author="example" id="3">
+    <sqlFile
+      path="classpath:org/springframework/batch/core/schema-postgresql.sql"
+      splitStatements="true"
+      stripComments="true"
+    />
+  </changeSet>
+</databaseChangeLog>

--- a/liquibase-linter-maven-plugin/src/test/resources-its/io/github/liquibaselinter/mavenplugin/LintMojoIT/detect_and_parse_all_changelogs/src/main/resources/config/liquibase/master.xml
+++ b/liquibase-linter-maven-plugin/src/test/resources-its/io/github/liquibaselinter/mavenplugin/LintMojoIT/detect_and_parse_all_changelogs/src/main/resources/config/liquibase/master.xml
@@ -5,4 +5,5 @@
 >
   <include file="config/liquibase/changelog/001_create_table_example.xml" relativeToChangelogFile="false" />
   <include file="classpath:config/liquibase/changelog/002_create_index_example.xml" />
+  <include file="changelog/003_create_spring_batch_schema.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>


### PR DESCRIPTION
This 'classpath:' prefix is supported by Liquibase when ran from Spring, so it makes sense to support it too 
Fixes #128