### PR TITLE
fix: ConsoleReporter should not close System.out once reporting

### DIFF
--- a/liquibase-linter-core/src/main/java/io/github/liquibaselinter/report/ConsoleReporter.java
+++ b/liquibase-linter-core/src/main/java/io/github/liquibaselinter/report/ConsoleReporter.java
@@ -19,10 +19,9 @@ public class ConsoleReporter extends TextReporter {
     @Override
     protected void process(Report report, List<ReportItem> items) {
         installAnsi();
-        try (PrintWriter writer = new PrintWriter(System.out)) {
-            printReport(writer, report, items);
-            writer.flush();
-        }
+        PrintWriter writer = new PrintWriter(System.out);
+        printReport(writer, report, items);
+        writer.flush();
         uninstallAnsi();
     }
 

--- a/liquibase-linter-core/src/main/java/io/github/liquibaselinter/report/ConsoleReporter.java
+++ b/liquibase-linter-core/src/main/java/io/github/liquibaselinter/report/ConsoleReporter.java
@@ -17,6 +17,7 @@ public class ConsoleReporter extends TextReporter {
     }
 
     @Override
+    @SuppressWarnings("PMD.CloseResource")
     protected void process(Report report, List<ReportItem> items) {
         installAnsi();
         PrintWriter writer = new PrintWriter(System.out);


### PR DESCRIPTION
System.out is not meant to be closed since data sent to System.out later on won't be displayed