### PR TITLE
Fix loading changelogs with 'classpath:' prefix on Windows

### DIFF
--- a/liquibase-linter-maven-plugin/src/main/java/io/github/liquibaselinter/mavenplugin/LintMojo.java
+++ b/liquibase-linter-maven-plugin/src/main/java/io/github/liquibaselinter/mavenplugin/LintMojo.java
@@ -26,7 +26,6 @@ import liquibase.database.OfflineConnection;
 import liquibase.exception.LiquibaseException;
 import liquibase.integration.spring.SpringResourceAccessor;
 import liquibase.resource.CompositeResourceAccessor;
-import liquibase.resource.DirectoryResourceAccessor;
 import liquibase.resource.ResourceAccessor;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -112,7 +111,10 @@ public class LintMojo extends AbstractMojo {
             SpringResourceAccessor springResourceAccessor = new SpringResourceAccessor(
                 new DefaultResourceLoader(classLoaderIncludingProjectClasspath())
             );
-            ResourceAccessor baseDirResourceAccessor = new DirectoryResourceAccessor(mavenProject.getBasedir());
+            ResourceAccessor baseDirResourceAccessor = new SafeDirectoryResourceAccessor(
+                mavenProject.getBasedir(),
+                getLog()
+            );
         ) {
             return new CompositeResourceAccessor(springResourceAccessor, baseDirResourceAccessor);
         } catch (Exception exception) {

--- a/liquibase-linter-maven-plugin/src/main/java/io/github/liquibaselinter/mavenplugin/SafeDirectoryResourceAccessor.java
+++ b/liquibase-linter-maven-plugin/src/main/java/io/github/liquibaselinter/mavenplugin/SafeDirectoryResourceAccessor.java
@@ -1,0 +1,29 @@
+package io.github.liquibaselinter.mavenplugin;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.util.ArrayList;
+import java.util.List;
+import liquibase.resource.Resource;
+import org.apache.maven.plugin.logging.Log;
+
+public class SafeDirectoryResourceAccessor extends liquibase.resource.DirectoryResourceAccessor {
+
+    private final Log log;
+
+    public SafeDirectoryResourceAccessor(File directory, Log log) throws FileNotFoundException {
+        super(directory);
+        this.log = log;
+    }
+
+    @Override
+    public List<Resource> getAll(String path) {
+        try {
+            return super.getAll(path);
+        } catch (Exception e) {
+            log.info(e.getMessage());
+        }
+
+        return new ArrayList<>();
+    }
+}


### PR DESCRIPTION
Fix #128