### PR TITLE
Disable ANSI coloring in default console and introduce additional reporter: `ansi-console`

### DIFF
--- a/liquibase-linter-core/src/main/java/io/github/liquibaselinter/config/ConfigLoader.java
+++ b/liquibase-linter-core/src/main/java/io/github/liquibaselinter/config/ConfigLoader.java
@@ -47,7 +47,10 @@ public final class ConfigLoader {
 
     private static Config defaultConfig() {
         ImmutableListMultimap.Builder<String, Reporter> reportingConfigBuilder = new ImmutableListMultimap.Builder<>();
-        reportingConfigBuilder.put("console", new ConsoleReporter(ReporterConfig.builder().withEnabled(true).build()));
+        reportingConfigBuilder.put(
+            ConsoleReporter.NAME,
+            new ConsoleReporter(ReporterConfig.builder().withEnabled(true).build())
+        );
         return new Config.Builder().withReporting(reportingConfigBuilder.build()).build();
     }
 

--- a/liquibase-linter-core/src/main/java/io/github/liquibaselinter/report/AnsiConsoleReporter.java
+++ b/liquibase-linter-core/src/main/java/io/github/liquibaselinter/report/AnsiConsoleReporter.java
@@ -1,0 +1,78 @@
+package io.github.liquibaselinter.report;
+
+import static org.fusesource.jansi.Ansi.ansi;
+
+import com.google.auto.service.AutoService;
+import java.io.PrintWriter;
+import java.util.List;
+import org.fusesource.jansi.Ansi;
+import org.fusesource.jansi.AnsiConsole;
+
+public class AnsiConsoleReporter extends ConsoleReporter {
+
+    public static final String NAME = "ansi-console";
+
+    public AnsiConsoleReporter(ReporterConfig config) {
+        super(config);
+    }
+
+    @Override
+    @SuppressWarnings("PMD.CloseResource")
+    protected void process(Report report, List<ReportItem> items) {
+        installAnsi();
+        super.process(report, items);
+        uninstallAnsi();
+    }
+
+    @Override
+    protected void printItemTypeName(PrintWriter output, ReportItem.ReportItemType type) {
+        switch (type) {
+            case ERROR:
+                printColoured(output, Ansi.Color.RED, type.name());
+                break;
+            case IGNORED:
+                printColoured(output, Ansi.Color.YELLOW, type.name());
+                break;
+            case PASSED:
+                printColoured(output, Ansi.Color.GREEN, type.name());
+                break;
+            default:
+                super.printItemTypeName(output, type);
+                break;
+        }
+    }
+
+    private void printColoured(PrintWriter output, Ansi.Color colour, String line) {
+        output.print(ansi().reset().fg(colour).a(line).reset().toString());
+    }
+
+    @Override
+    protected void printSummaryDisabledRules(PrintWriter output, Report report) {
+        long disabled = countDisabledRules(report);
+
+        output.append('\t');
+        if (disabled > 0) {
+            printColoured(output, Ansi.Color.MAGENTA, "DISABLED");
+        } else {
+            // don't draw attention with color when there are no report items
+            output.print("DISABLED");
+        }
+        output.append(": ").println(disabled);
+    }
+
+    protected void installAnsi() {
+        AnsiConsole.systemInstall();
+    }
+
+    protected void uninstallAnsi() {
+        AnsiConsole.systemUninstall();
+    }
+
+    @AutoService(Reporter.Factory.class)
+    public static class Factory extends AbstractReporter.Factory<AnsiConsoleReporter> {
+
+        public Factory() {
+            super(NAME);
+        }
+    }
+}

--- a/liquibase-linter-core/src/main/java/io/github/liquibaselinter/report/ConsoleReporter.java
+++ b/liquibase-linter-core/src/main/java/io/github/liquibaselinter/report/ConsoleReporter.java
@@ -1,12 +1,8 @@
 package io.github.liquibaselinter.report;
 
-import static org.fusesource.jansi.Ansi.ansi;
-
 import com.google.auto.service.AutoService;
 import java.io.PrintWriter;
 import java.util.List;
-import org.fusesource.jansi.Ansi;
-import org.fusesource.jansi.AnsiConsole;
 
 public class ConsoleReporter extends TextReporter {
 
@@ -19,11 +15,9 @@ public class ConsoleReporter extends TextReporter {
     @Override
     @SuppressWarnings("PMD.CloseResource")
     protected void process(Report report, List<ReportItem> items) {
-        installAnsi();
         PrintWriter writer = new PrintWriter(System.out);
         printReport(writer, report, items);
         writer.flush();
-        uninstallAnsi();
     }
 
     @Override
@@ -44,47 +38,15 @@ public class ConsoleReporter extends TextReporter {
         output.append(": ").println(items.size());
     }
 
-    private void printItemTypeName(PrintWriter output, ReportItem.ReportItemType type) {
-        switch (type) {
-            case ERROR:
-                printColoured(output, Ansi.Color.RED, type.name());
-                break;
-            case IGNORED:
-                printColoured(output, Ansi.Color.YELLOW, type.name());
-                break;
-            case PASSED:
-                printColoured(output, Ansi.Color.GREEN, type.name());
-                break;
-            default:
-                super.printItemTypeHeader(output, type);
-                break;
-        }
-    }
-
-    private void printColoured(PrintWriter output, Ansi.Color colour, String line) {
-        output.print(ansi().reset().fg(colour).a(line).reset().toString());
+    protected void printItemTypeName(PrintWriter output, ReportItem.ReportItemType type) {
+        output.print(type.name());
     }
 
     @Override
     protected void printSummaryDisabledRules(PrintWriter output, Report report) {
-        long disabled = countDisabledRules(report);
-
         output.append('\t');
-        if (disabled > 0) {
-            output.print(ansi().reset().fg(Ansi.Color.MAGENTA).a("DISABLED").reset().toString());
-        } else {
-            // don't draw attention with color when there are no report items
-            output.print("DISABLED");
-        }
-        output.append(": ").println(disabled);
-    }
-
-    protected void installAnsi() {
-        AnsiConsole.systemInstall();
-    }
-
-    protected void uninstallAnsi() {
-        AnsiConsole.systemUninstall();
+        output.print("DISABLED");
+        output.append(": ").println(countDisabledRules(report));
     }
 
     @AutoService(Reporter.Factory.class)

--- a/liquibase-linter-core/src/test/java/io/github/liquibaselinter/report/AnsiConsoleReporterTest.java
+++ b/liquibase-linter-core/src/test/java/io/github/liquibaselinter/report/AnsiConsoleReporterTest.java
@@ -10,7 +10,7 @@ import java.io.PrintStream;
 import org.fusesource.jansi.io.HtmlAnsiOutputStream;
 import org.junit.jupiter.api.Test;
 
-class ConsoleReporterTest {
+class AnsiConsoleReporterTest {
 
     @Test
     void emptyReport() {
@@ -54,10 +54,27 @@ class ConsoleReporterTest {
             ByteArrayOutputStream outContent = new ByteArrayOutputStream();
             PrintStream out = new PrintStream(new HtmlAnsiOutputStream(outContent));
             System.setOut(out);
-            new ConsoleReporter(reporterConfig).processReport(report);
+            new TestAnsiConsoleReporter(reporterConfig).processReport(report);
             return outContent.toString();
         } finally {
             System.setOut(originalOut);
+        }
+    }
+
+    private static class TestAnsiConsoleReporter extends AnsiConsoleReporter {
+
+        TestAnsiConsoleReporter(ReporterConfig config) {
+            super(config);
+        }
+
+        @Override
+        protected void installAnsi() {
+            // ansi is difficult to test with so noop installing makes it easier
+        }
+
+        @Override
+        protected void uninstallAnsi() {
+            // ansi is difficult to test with so noop uninstalling makes it easier
         }
     }
 }

--- a/liquibase-linter-core/src/test/resources/io/github/liquibaselinter/report/AnsiConsoleReporterTest.allFilters.approved.txt
+++ b/liquibase-linter-core/src/test/resources/io/github/liquibaselinter/report/AnsiConsoleReporterTest.allFilters.approved.txt
@@ -1,0 +1,38 @@
+src/main/resources/ddl/first.xml
+<span style="color: red;">ERROR</span>
+	'error-rule': Error message 1
+<span style="color: yellow;">IGNORED</span>
+	'ignored-rule': Ignored message 1
+<span style="color: green;">PASSED</span>
+	'passed-rule': Passed message 1
+changeSet '2020010101'
+<span style="color: red;">ERROR</span>
+	'error-rule': Error message 2
+<span style="color: yellow;">IGNORED</span>
+	'ignored-rule': Ignored message 2
+<span style="color: green;">PASSED</span>
+	'passed-rule': Passed message 2
+changeSet '2020010102'
+<span style="color: red;">ERROR</span>
+	'error-rule': Error message 3.1
+	'error-rule': Error message 3.2
+<span style="color: yellow;">IGNORED</span>
+	'ignored-rule': Ignored message 3
+<span style="color: green;">PASSED</span>
+	'passed-rule': Passed message 3
+
+src/main/resources/ddl/second.xml
+changeSet '2020010103'
+<span style="color: red;">ERROR</span>
+	'error-rule': Error message 4
+		with newline
+
+Other
+<span style="color: red;">ERROR</span>
+	'error-rule': No change log
+
+Summary:
+	<span style="color: red;">ERROR</span>: 6
+	<span style="color: yellow;">IGNORED</span>: 3
+	<span style="color: green;">PASSED</span>: 3
+	<span style="color: magenta;">DISABLED</span>: 2

--- a/liquibase-linter-core/src/test/resources/io/github/liquibaselinter/report/AnsiConsoleReporterTest.defaultFilters.approved.txt
+++ b/liquibase-linter-core/src/test/resources/io/github/liquibaselinter/report/AnsiConsoleReporterTest.defaultFilters.approved.txt
@@ -1,0 +1,32 @@
+src/main/resources/ddl/first.xml
+<span style="color: red;">ERROR</span>
+	'error-rule': Error message 1
+<span style="color: yellow;">IGNORED</span>
+	'ignored-rule': Ignored message 1
+changeSet '2020010101'
+<span style="color: red;">ERROR</span>
+	'error-rule': Error message 2
+<span style="color: yellow;">IGNORED</span>
+	'ignored-rule': Ignored message 2
+changeSet '2020010102'
+<span style="color: red;">ERROR</span>
+	'error-rule': Error message 3.1
+	'error-rule': Error message 3.2
+<span style="color: yellow;">IGNORED</span>
+	'ignored-rule': Ignored message 3
+
+src/main/resources/ddl/second.xml
+changeSet '2020010103'
+<span style="color: red;">ERROR</span>
+	'error-rule': Error message 4
+		with newline
+
+Other
+<span style="color: red;">ERROR</span>
+	'error-rule': No change log
+
+Summary:
+	<span style="color: red;">ERROR</span>: 6
+	<span style="color: yellow;">IGNORED</span>: 3
+	<span style="color: green;">PASSED</span>: 3
+	<span style="color: magenta;">DISABLED</span>: 2

--- a/liquibase-linter-core/src/test/resources/io/github/liquibaselinter/report/AnsiConsoleReporterTest.emptyReport.approved.txt
+++ b/liquibase-linter-core/src/test/resources/io/github/liquibaselinter/report/AnsiConsoleReporterTest.emptyReport.approved.txt
@@ -1,0 +1,5 @@
+Summary:
+	ERROR: 0
+	IGNORED: 0
+	PASSED: 0
+	DISABLED: 0

--- a/liquibase-linter-core/src/test/resources/io/github/liquibaselinter/report/AnsiConsoleReporterTest.errorFilter.approved.txt
+++ b/liquibase-linter-core/src/test/resources/io/github/liquibaselinter/report/AnsiConsoleReporterTest.errorFilter.approved.txt
@@ -1,0 +1,26 @@
+src/main/resources/ddl/first.xml
+<span style="color: red;">ERROR</span>
+	'error-rule': Error message 1
+changeSet '2020010101'
+<span style="color: red;">ERROR</span>
+	'error-rule': Error message 2
+changeSet '2020010102'
+<span style="color: red;">ERROR</span>
+	'error-rule': Error message 3.1
+	'error-rule': Error message 3.2
+
+src/main/resources/ddl/second.xml
+changeSet '2020010103'
+<span style="color: red;">ERROR</span>
+	'error-rule': Error message 4
+		with newline
+
+Other
+<span style="color: red;">ERROR</span>
+	'error-rule': No change log
+
+Summary:
+	<span style="color: red;">ERROR</span>: 6
+	<span style="color: yellow;">IGNORED</span>: 3
+	<span style="color: green;">PASSED</span>: 3
+	<span style="color: magenta;">DISABLED</span>: 2

--- a/liquibase-linter-core/src/test/resources/io/github/liquibaselinter/report/ConsoleReporterTest.allFilters.approved.txt
+++ b/liquibase-linter-core/src/test/resources/io/github/liquibaselinter/report/ConsoleReporterTest.allFilters.approved.txt
@@ -1,38 +1,38 @@
 src/main/resources/ddl/first.xml
-<span style="color: red;">ERROR</span>
+ERROR
 	'error-rule': Error message 1
-<span style="color: yellow;">IGNORED</span>
+IGNORED
 	'ignored-rule': Ignored message 1
-<span style="color: green;">PASSED</span>
+PASSED
 	'passed-rule': Passed message 1
 changeSet '2020010101'
-<span style="color: red;">ERROR</span>
+ERROR
 	'error-rule': Error message 2
-<span style="color: yellow;">IGNORED</span>
+IGNORED
 	'ignored-rule': Ignored message 2
-<span style="color: green;">PASSED</span>
+PASSED
 	'passed-rule': Passed message 2
 changeSet '2020010102'
-<span style="color: red;">ERROR</span>
+ERROR
 	'error-rule': Error message 3.1
 	'error-rule': Error message 3.2
-<span style="color: yellow;">IGNORED</span>
+IGNORED
 	'ignored-rule': Ignored message 3
-<span style="color: green;">PASSED</span>
+PASSED
 	'passed-rule': Passed message 3
 
 src/main/resources/ddl/second.xml
 changeSet '2020010103'
-<span style="color: red;">ERROR</span>
+ERROR
 	'error-rule': Error message 4
 		with newline
 
 Other
-<span style="color: red;">ERROR</span>
+ERROR
 	'error-rule': No change log
 
 Summary:
-	<span style="color: red;">ERROR</span>: 6
-	<span style="color: yellow;">IGNORED</span>: 3
-	<span style="color: green;">PASSED</span>: 3
-	<span style="color: magenta;">DISABLED</span>: 2
+	ERROR: 6
+	IGNORED: 3
+	PASSED: 3
+	DISABLED: 2

--- a/liquibase-linter-core/src/test/resources/io/github/liquibaselinter/report/ConsoleReporterTest.defaultFilters.approved.txt
+++ b/liquibase-linter-core/src/test/resources/io/github/liquibaselinter/report/ConsoleReporterTest.defaultFilters.approved.txt
@@ -1,32 +1,32 @@
 src/main/resources/ddl/first.xml
-<span style="color: red;">ERROR</span>
+ERROR
 	'error-rule': Error message 1
-<span style="color: yellow;">IGNORED</span>
+IGNORED
 	'ignored-rule': Ignored message 1
 changeSet '2020010101'
-<span style="color: red;">ERROR</span>
+ERROR
 	'error-rule': Error message 2
-<span style="color: yellow;">IGNORED</span>
+IGNORED
 	'ignored-rule': Ignored message 2
 changeSet '2020010102'
-<span style="color: red;">ERROR</span>
+ERROR
 	'error-rule': Error message 3.1
 	'error-rule': Error message 3.2
-<span style="color: yellow;">IGNORED</span>
+IGNORED
 	'ignored-rule': Ignored message 3
 
 src/main/resources/ddl/second.xml
 changeSet '2020010103'
-<span style="color: red;">ERROR</span>
+ERROR
 	'error-rule': Error message 4
 		with newline
 
 Other
-<span style="color: red;">ERROR</span>
+ERROR
 	'error-rule': No change log
 
 Summary:
-	<span style="color: red;">ERROR</span>: 6
-	<span style="color: yellow;">IGNORED</span>: 3
-	<span style="color: green;">PASSED</span>: 3
-	<span style="color: magenta;">DISABLED</span>: 2
+	ERROR: 6
+	IGNORED: 3
+	PASSED: 3
+	DISABLED: 2

--- a/liquibase-linter-core/src/test/resources/io/github/liquibaselinter/report/ConsoleReporterTest.errorFilter.approved.txt
+++ b/liquibase-linter-core/src/test/resources/io/github/liquibaselinter/report/ConsoleReporterTest.errorFilter.approved.txt
@@ -1,26 +1,26 @@
 src/main/resources/ddl/first.xml
-<span style="color: red;">ERROR</span>
+ERROR
 	'error-rule': Error message 1
 changeSet '2020010101'
-<span style="color: red;">ERROR</span>
+ERROR
 	'error-rule': Error message 2
 changeSet '2020010102'
-<span style="color: red;">ERROR</span>
+ERROR
 	'error-rule': Error message 3.1
 	'error-rule': Error message 3.2
 
 src/main/resources/ddl/second.xml
 changeSet '2020010103'
-<span style="color: red;">ERROR</span>
+ERROR
 	'error-rule': Error message 4
 		with newline
 
 Other
-<span style="color: red;">ERROR</span>
+ERROR
 	'error-rule': No change log
 
 Summary:
-	<span style="color: red;">ERROR</span>: 6
-	<span style="color: yellow;">IGNORED</span>: 3
-	<span style="color: green;">PASSED</span>: 3
-	<span style="color: magenta;">DISABLED</span>: 2
+	ERROR: 6
+	IGNORED: 3
+	PASSED: 3
+	DISABLED: 2

--- a/website/docs/reporting/ansi-console.md
+++ b/website/docs/reporting/ansi-console.md
@@ -1,0 +1,15 @@
+---
+title: ANSI Console
+---
+
+## Name
+
+`ansi-console`
+
+## Format
+
+Similar to the `console` reporter, but with colors for highlighting violations.
+
+## Options
+
+No extra options.

--- a/website/docs/reporting/console.md
+++ b/website/docs/reporting/console.md
@@ -2,9 +2,13 @@
 title: Console
 ---
 
+## Name
+
+`console`
+
 ## Format
 
-Displays the linting results to the system console, including coloring violations.
+Displays the linting results to the system console.
 
 ## Options
 

--- a/website/docs/reporting/index.md
+++ b/website/docs/reporting/index.md
@@ -9,7 +9,7 @@ Liquibase Linter has several types of reporters that you can turn on and configu
 
 By default, only the [`console`](console.md) reporter is enabled.
 
-The simmplest way to use a reporter is to simply enable it:
+The simplest way to use a reporter is to simply enable it:
 
 ```json
 {

--- a/website/docs/reporting/markdown.md
+++ b/website/docs/reporting/markdown.md
@@ -2,6 +2,10 @@
 title: Markdown
 ---
 
+## Name
+
+`markdown`
+
 ## Format
 
 Displays the linting results to a standard Markdown `.md` file. By default, the report

--- a/website/docs/reporting/text.md
+++ b/website/docs/reporting/text.md
@@ -2,6 +2,10 @@
 title: Text
 ---
 
+## Name
+
+`text`
+
 ## Format
 
 Displays the linting results to a standard `.txt` file. By default, the report

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -55,7 +55,7 @@
       {
         "type": "category",
         "label": "Core Reporters",
-        "items": ["reporting/console", "reporting/markdown", "reporting/text"]
+        "items": ["reporting/console", "reporting/ansi-console", "reporting/markdown", "reporting/text"]
       },
       {
         "type": "category",


### PR DESCRIPTION
ANSI - with Jansi - has some issues, like not being well supported on Linux/AARCH64, and strange behavior on unexpected contexts.
So it's safer to disable it by default, and have opt-in support through the manual activation of `ansi-console` reporter
Fixes #107

The colored console can be enabled with the following configuration:
```json
{
  "reporting": {
    "console": false
    "ansi-console": true
  }
}
```
