### PR TITLE
chore(deps): prevent updates to Liquibase 5+ since it is no longer open-source

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,9 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+    ignore:
+      - dependency-name: 'org.liquibase:liquibase-core'
+        version: '[5.0.0,)' # Liquibase 5+ is no longer open-source
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:


### PR DESCRIPTION
https://docs.liquibase.com/community/release-notes/5-0

> Liquibase Community 5.0+ ships with the Functional Source License (FSL)
> "The Functional Source License (FSL) is a Fair Source license that converts to Apache 2.0 or MIT after two years. It is designed for SaaS companies that value both user freedom and developer sustainability. FSL provides everything a developer needs to use and learn from your software without harmful free-riding."
> Learn more at https://fsl.software/